### PR TITLE
Fixed missed threat abilities causing threat

### DIFF
--- a/ClassModules/Classic/Warrior.lua
+++ b/ClassModules/Classic/Warrior.lua
@@ -128,12 +128,16 @@ local threatValues = {
 }
 
 local function init(self, t, f)
-	local func = function(self, spellID, target)
-		self:AddTargetThreat(target, f(self, spellID))
-	end
-	for k, v in pairs(t) do
-		self.CastLandedHandlers[k] = func
-	end
+    local castHandler = function(self, spellID, target)
+        self:AddTargetThreat(target, f(self, spellID))
+    end
+    local castMissHandler = function(self, spellID, target)
+        self:AddTargetThreat(target, -f(self, spellID))
+    end
+    for k, v in pairs(t) do
+        self.CastLandedHandlers[k] = castHandler
+        self.CastMissHandlers[v] = castMissHandler
+    end
 end
 
 function Warrior:ClassInit()

--- a/LibThreatClassic2.lua
+++ b/LibThreatClassic2.lua
@@ -88,7 +88,7 @@ if _G.WOW_PROJECT_ID ~= _G.WOW_PROJECT_CLASSIC then return end
 
 _G.THREATLIB_LOAD_MODULES = false -- don't load modules unless we update this file
 
-local MAJOR, MINOR = "LibThreatClassic2", 9 -- Bump minor on changes, Major is constant lib identifier
+local MAJOR, MINOR = "LibThreatClassic2", 10 -- Bump minor on changes, Major is constant lib identifier
 assert(LibStub, MAJOR .. " requires LibStub")
 
 -- if this version or a newer one is already installed, go no further


### PR DESCRIPTION
This pull request corrects that warrior abilities no longer applies their flat threat modifier when the ability is missed, dodged or parrried. 

It's not fully tested for blocks and immunities. But, it's still more correct then the current state.

This changed is based on a Vael wipe last night where threat meter showed the tank as way ahead, however a dps warrior pulled aggro regardless. The discrepency lines up exactly with lib believing that missed abilities caused threat, and the game not.

This also agrees with the threat analysis site  http://82.130.21.56/threat/, which also doesn't credit misses with threat

Log Tank: https://classic.warcraftlogs.com/reports/PXFzHGnba9AgfctK/#type=summary&fight=5&view=events&source=10
Log DPS:  https://classic.warcraftlogs.com/reports/PXFzHGnba9AgfctK/#type=summary&fight=5&view=events&source=17
Video: (Fight starts at 00:16:51) https://www.twitch.tv/videos/586576228
Spreadsheet: https://docs.google.com/spreadsheets/d/1IUk2yrDuR7l-R8uN9phKlxttcYP1NfXlsUQ3kpdZp4A/edit?usp=sharing
