### PR TITLE
Prioritize communication from tanks

### DIFF
--- a/LibThreatClassic2.lua
+++ b/LibThreatClassic2.lua
@@ -398,12 +398,22 @@ function ThreatLib:OnCommReceived(prefix, message, distribution, sender)
 end
 
 function ThreatLib:SendComm(distribution, command, ...)
-	self:SendCommMessage(self.prefix, self:Serialize(self:Memoize(command), ...), distribution)
+	local priority = "NORMAL"
+	if classModule and classModule.isTanking then
+		priority = "ALERT"
+	end
+  
+	self:SendCommMessage(self.prefix, self:Serialize(self:Memoize(command), ...), distribution, nil, priority)
 end
 
 function ThreatLib:SendCommRaw(distribution, command, data)
+	local priority = "NORMAL"
+	if classModule and classModule.isTanking then
+		priority = "ALERT"
+	end
+	
 	local str = self:Memoize(command) .. data
-	self:SendCommMessage(self.prefix, str, distribution)
+	self:SendCommMessage(self.prefix, str, distribution, nil, priority)
 end
 
 function ThreatLib:SendCommWhisper(distribution, to, command, ...)


### PR DESCRIPTION
This helps mitigate the problem where a tanks threat updates might be delayed because of other addons communicating. There are more improvements that can be done to the addon communication like discarding old updates that are still enqueued in ChatThrottleLib, but that would require doing changes in that library. Another thing to consider that could be done right now is monitor the communication delay using callbacks and notify the user if the delay is significant so that they can call out their threat manually in comms or turn off other addons.